### PR TITLE
Make eccf array input and test for that

### DIFF
--- a/climlab_cam3_radiation/Driver.f90
+++ b/climlab_cam3_radiation/Driver.f90
@@ -15,6 +15,8 @@
 !  Return flux at layer interfaces rather than averaging to get flux at layer centers
 !
 !  Return clear-sky fluxes too
+!
+!  New February 2025: eccf is an array input now
 
 subroutine driver(  &
      km,   &
@@ -77,7 +79,7 @@ subroutine driver(  &
   real*8, intent(in) :: aldir(jm,im)
   real*8, intent(in) :: asdif(jm,im)
   real*8, intent(in) :: asdir(jm,im)
-  real*8, intent(in) :: eccf
+  real*8, intent(in) :: eccf(jm,im)
   real*8, intent(in) :: coszen(jm,im)
   real*8, intent(in) :: scon
   real*8, intent(in) :: flus(jm,im)
@@ -130,7 +132,7 @@ subroutine driver(  &
   real*8, intent(out) :: srfflx(jm,im)
 
   !  These are not comments! Necessary directives to f2py to handle array dimensions
-  !f2py depend(jm,im) aldif,aldir,asdif,asdir,coszen,flus,ps,tg
+  !f2py depend(jm,im) aldif,aldir,asdif,asdir,coszen,flus,ps,tg,eccf
   !f2py depend(km,jm,im) cldf,clwp,ciwp,o3mmr,r_liq,r_ice,pmid,dp,q,t
   !f2py depend(jm,im) sw_cf_toa,sw_cf_srf,lw_cf_toa,lw_cf_srf,lw_toa,lw_srf,sw_toa,sw_srf,srfflx
   !f2py depend(km,jm,im) swflx_out,swflxc_out,lwflx_out,lwflxc_out
@@ -174,7 +176,7 @@ subroutine driver(  &
              aldir(j,i),  &
              asdif(j,i),  &
              asdir(j,i),  &
-             eccf,        &
+             eccf(j,i),   &
              coszen(j,i), &
              scon,        &
              flus(j,i),   &


### PR DESCRIPTION
Following recent work in climlab-rrtmg, this PR makes the input factor `eccf` (the irradiance factor) an array input.

Also includes a new test for multicolumn input to the CAM3 radiation code and tests to see if variations in the irradiance factor work as expected.